### PR TITLE
 update esp8266 program example -- extend reset delay

### DIFF
--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -382,7 +382,7 @@ class miniesptool: # pylint: disable=invalid-name
         self._resetpin.value = False
         time.sleep(0.1)
         self._resetpin.value = True
-        time.sleep(0.2)
+        time.sleep(1.0)
 
     def flash_block(self, data, seq, timeout=0.1):
         """Send one block of data to program into SPI Flash memory"""

--- a/examples/miniesptool_esp8266program.py
+++ b/examples/miniesptool_esp8266program.py
@@ -19,6 +19,12 @@ esptool.sync()
 print("Synced")
 print(esptool.chip_name)
 print("MAC ADDR: ", [hex(i) for i in esptool.mac_addr])
-esptool.flash_file("AT_firmware_1.6.2.0.bin")
+esptool.flash_file("esp8266/AT_firmware_1.6.2.0.bin", 0x0 )
+# 0x3FC000 esp_init_data_default_v05.bin
+esptool.flash_file("esp8266/esp_init_data_default_v05.bin", 0x3FC000)
+# 0x3FE000 blank.bin
+esptool.flash_file("esp8266/esp_init_data_default_v05.bin", 0x3FE000)
 esptool.reset()
 time.sleep(0.5)
+
+

--- a/examples/miniesptool_esp8266program.py
+++ b/examples/miniesptool_esp8266program.py
@@ -26,5 +26,3 @@ esptool.flash_file("esp8266/esp_init_data_default_v05.bin", 0x3FC000)
 esptool.flash_file("esp8266/esp_init_data_default_v05.bin", 0x3FE000)
 esptool.reset()
 time.sleep(0.5)
-
-


### PR DESCRIPTION
I had some trouble getting it to sync with the nrf52840 after reset until I extended the delay. It is more reliable now. 

It was noted that it the ESP8266 wsa completely erased, then loading AT_firmware_1.6.2.0.bin  left the board in a non functional state withe the blue led flashing rapidly.

The AT_firmeare_1.6.2.0.bin file is missing a small load of the esp_init_data_default.bin which goes at 0x3fc000 -- rather than make a 4Mbyte single file just add the load of this file as a separate piece.
I also added the recommended "blank.bin" load at 0x3fe000 - doesn't hurt.

the update miniesptool_esp8266program.py assumes the 3 necessary files are in a folder named esp8266
