### PR TITLE
 fix upload example file name

### DIFF
--- a/examples/miniesptool_esp8266program.py
+++ b/examples/miniesptool_esp8266program.py
@@ -23,6 +23,6 @@ esptool.flash_file("esp8266/AT_firmware_1.6.2.0.bin", 0x0 )
 # 0x3FC000 esp_init_data_default_v05.bin
 esptool.flash_file("esp8266/esp_init_data_default_v05.bin", 0x3FC000)
 # 0x3FE000 blank.bin
-esptool.flash_file("esp8266/esp_init_data_default_v05.bin", 0x3FE000)
+esptool.flash_file("esp8266/blank.bin", 0x3FE000)
 esptool.reset()
 time.sleep(0.5)


### PR DESCRIPTION
oops -- cut/paste error - loaded wrong file in place of blank.bin at 0x3fe000.  Does not appear to have caused any problems, but now it's fixed.