### PR TITLE
Fix escape bug

### DIFF
--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -350,7 +350,7 @@ class miniesptool:  # pylint: disable=invalid-name
                     escaped_byte = True
                 elif escaped_byte:
                     if c == b"\xDD":
-                        reply += b"\xDC"
+                        reply += b"\xDB"
                     elif c == b"\xDC":
                         reply += b"\xC0"
                     else:


### PR DESCRIPTION
https://github.com/espressif/esptool/wiki/Serial-Protocol#low-level-protocol
Each SLIP packet begins and ends with 0xC0. Within the packet, all occurrences of 0xC0 and 0xDB are replaced with 0xDB 0xDC and 0xDB 0xDD, respectively. The replacing is to be done after the checksum and lengths are calculated, so the packet length may be longer than the size field below.

reply += b"\xDC" ===>> reply += b"\xDB"