### PR TITLE
[Feature] Add Support for ESP32-C6 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Introduction
     :target: https://github.com/astral-sh/ruff
     :alt: Code Style: Ruff
 
-ROM loader for ESP chips, works with ESP8266 or ESP32.
+ROM loader for ESP chips, works with ESP8266, ESP32, or ESP32-C6.
 This is a 'no-stub' loader, so you can't read MD5 or firmware back on ESP8266.
 
 See this document for protocol we're implementing:
@@ -67,7 +67,7 @@ To install in a virtual environment in your current project:
 Usage Example
 =============
 
-Check the examples folder for demo sketches to upload firmware to ESP8266 and ESP32
+Check the examples folder for demo sketches to upload firmware to ESP8266, ESP32, and ESP32-C6.
 
 Documentation
 =============

--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -47,7 +47,9 @@ ESP32_DATAREGVALUE = 0x15122500
 ESP8266_DATAREGVALUE = 0x00062000
 ESP32_C6_DATAREGVALUE = 0x2CE0806F
 ESP8266_ESP32_REG_DATA = 0x60000078
-ESP32_C6_REG_DATA = 0x40001000  # from https://github.com/espressif/esptool-js/blob/main/src/esploader.ts
+ESP32_C6_REG_DATA = (
+    0x40001000  # from https://github.com/espressif/esptool-js/blob/main/src/esploader.ts
+)
 
 
 # Commands supported by ESP8266 ROM bootloader
@@ -267,9 +269,7 @@ class miniesptool:
         if self._chipfamily in (ESP32, ESP32C6):
             self.check_command(ESP_SPI_ATTACH, bytes([0] * 8))
             # We are hardcoded for 4MB flash on ESP32
-            buffer = struct.pack(
-                "<IIIIII", 0, self._flashsize, 0x10000, 4096, 256, 0xFFFF
-            )
+            buffer = struct.pack("<IIIIII", 0, self._flashsize, 0x10000, 4096, 256, 0xFFFF)
             self.check_command(ESP_SPI_SET_PARAMS, buffer)
 
         num_blocks = (size + self._flash_write_size - 1) // self._flash_write_size
@@ -285,19 +285,14 @@ class miniesptool:
                 "<IIIII", erase_size, num_blocks, self._flash_write_size, offset, 0
             )
         else:
-            buffer = struct.pack(
-                "<IIII", erase_size, num_blocks, self._flash_write_size, offset
-            )
+            buffer = struct.pack("<IIII", erase_size, num_blocks, self._flash_write_size, offset)
         print(
             "Erase size %d, num_blocks %d, size %d, offset 0x%04x"
             % (erase_size, num_blocks, self._flash_write_size, offset)
         )
         self.check_command(ESP_FLASH_BEGIN, buffer, timeout=timeout)
         if size != 0:
-            print(
-                "Took %.2fs to erase %d flash blocks"
-                % (time.monotonic() - stamp, num_blocks)
-            )
+            print("Took %.2fs to erase %d flash blocks" % (time.monotonic() - stamp, num_blocks))
         return num_blocks
 
     def check_command(self, opcode, buffer, checksum=0, timeout=0.1):

--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -264,7 +264,7 @@ class miniesptool:
     def flash_begin(self, *, size=0, offset=0):
         """Prepare for flashing by attaching SPI chip and erasing the
         number of blocks requred."""
-        if self._chipfamily == ESP32 or self._chipfamily == ESP32C6:
+        if self._chipfamily in (ESP32, ESP32C6):
             self.check_command(ESP_SPI_ATTACH, bytes([0] * 8))
             # We are hardcoded for 4MB flash on ESP32
             buffer = struct.pack(

--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -39,12 +39,16 @@ import time
 
 from digitalio import Direction
 
-__version__ = "0.0.0+auto.0"
+__version__ = "0.2.25"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_miniesptool.git"
 
 SYNC_PACKET = b"\x07\x07\x12 UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU"
 ESP32_DATAREGVALUE = 0x15122500
 ESP8266_DATAREGVALUE = 0x00062000
+ESP32_C6_DATAREGVALUE = 0x2ce0806f
+ESP8266_ESP32_REG_DATA = 0x60000078
+ESP32_C6_REG_DATA = 0x40001000 # from https://github.com/espressif/esptool-js/blob/main/src/esploader.ts
+
 
 # Commands supported by ESP8266 ROM bootloader
 ESP_FLASH_BEGIN = 0x02
@@ -64,6 +68,7 @@ ESP_CHECKSUM_MAGIC = 0xEF
 
 ESP8266 = 0x8266
 ESP32 = 0x32
+ESP32C6 = 0x326
 
 FLASH_SIZES = {
     "512KB": 0x00,
@@ -85,7 +90,7 @@ class miniesptool:
     when you have an ESP module wired to a board and need to upload new AT
     firmware. Its slow! Expect a few minutes when programming 1 MB flash."""
 
-    FLASH_WRITE_SIZE = 0x200
+    FLASH_WRITE_SIZE = 0x400
     FLASH_SECTOR_SIZE = 0x1000  # Flash sector size, minimum unit of erase.
     ESP_ROM_BAUD = 115200
 
@@ -178,19 +183,30 @@ class miniesptool:
             mac_addr[3] = mac1 >> 16 & 0xFF
             mac_addr[4] = mac1 >> 8 & 0xFF
             mac_addr[5] = mac1 & 0xFF
+        if self._chipfamily == ESP32C6:
+            mac_addr[0] = (mac1 >> 8) & 0xFF
+            mac_addr[1] = mac1 & 0xFF
+            mac_addr[2] = (mac0 >> 24) & 0xFF
+            mac_addr[3] = (mac0 >> 16) & 0xFF
+            mac_addr[4] = (mac0 >> 8) & 0xFF
+            mac_addr[5] = mac0 & 0xFF
         return mac_addr
 
     @property
     def chip_type(self):
-        """ESP32 or ESP8266 based on which chip type we're talking to"""
+        """Assigns ESP32, ESP32-C6, or ESP8266 based on which chip type we're talking to"""
         if not self._chipfamily:
-            datareg = self.read_register(0x60000078)
+            # Check for ESP32 or ESP8266
+            datareg = self.read_register(ESP8266_ESP32_REG_DATA)
             if datareg == ESP32_DATAREGVALUE:
                 self._chipfamily = ESP32
             elif datareg == ESP8266_DATAREGVALUE:
                 self._chipfamily = ESP8266
             else:
-                raise RuntimeError("Unknown Chip")
+                # Check for ESP32-C6
+                datareg = self.read_register(ESP32_C6_REG_DATA)
+                if (datareg == ESP32_C6_DATAREGVALUE):
+                    self._chipfamily = ESP32C6
         return self._chipfamily
 
     @property
@@ -206,14 +222,20 @@ class miniesptool:
             if self._efuses[0] & (1 << 4) or self._efuses[2] & (1 << 16):
                 return "ESP8285"
             return "ESP8266EX"
+        if self.chip_type == ESP32C6:
+            return "ESP32-C6"
         return None
 
     def _read_efuses(self):
         """Read the OTP data for this chip and store into _efuses array"""
+        # Attempt to read MAC from efuse registers
         if self._chipfamily == ESP8266:
             base_addr = 0x3FF00050
         elif self._chipfamily == ESP32:
             base_addr = 0x6001A000
+        elif self._chipfamily == ESP32C6:
+            # from https://github.com/espressif/esptool-js/blob/main/src/targets/esp32c6.ts
+            base_addr = 0x600B0844
         else:
             raise RuntimeError("Don't know what chip this is")
         for i in range(4):
@@ -239,7 +261,7 @@ class miniesptool:
     def flash_begin(self, *, size=0, offset=0):
         """Prepare for flashing by attaching SPI chip and erasing the
         number of blocks requred."""
-        if self._chipfamily == ESP32:
+        if self._chipfamily == ESP32 or self._chipfamily == ESP32C6:
             self.check_command(ESP_SPI_ATTACH, bytes([0] * 8))
             # We are hardcoded for 4MB flash on ESP32
             buffer = struct.pack("<IIIIII", 0, self._flashsize, 0x10000, 4096, 256, 0xFFFF)
@@ -252,12 +274,16 @@ class miniesptool:
             erase_size = size
         timeout = 13
         stamp = time.monotonic()
-        buffer = struct.pack("<IIII", erase_size, num_blocks, self.FLASH_WRITE_SIZE, offset)
+        if self._chipfamily == ESP32C6:
+            # ESP32-C6 requires a 5th parameter (the encryption flag)
+            buffer = struct.pack("<IIIII", erase_size, num_blocks, self.FLASH_WRITE_SIZE, offset, 0)
+        else:
+            buffer = struct.pack("<IIII", erase_size, num_blocks, self.FLASH_WRITE_SIZE, offset)
         print(
             "Erase size %d, num_blocks %d, size %d, offset 0x%04x"
             % (erase_size, num_blocks, self.FLASH_WRITE_SIZE, offset)
         )
-
+        print("Buffer: ", [hex(i) for i in buffer])
         self.check_command(ESP_FLASH_BEGIN, buffer, timeout=timeout)
         if size != 0:
             print("Took %.2fs to erase %d flash blocks" % (time.monotonic() - stamp, num_blocks))
@@ -279,9 +305,9 @@ class miniesptool:
             raise RuntimeError("Didn't get enough status bytes")
         status = data[-status_len:]
         data = data[:-status_len]
-        # print("status", status)
-        # print("value", value)
-        # print("data", data)
+        #print("status", status)
+        #print("value", value)
+        #print("data", data)
         if status[0] != 0:
             raise RuntimeError("Command failure error code 0x%02x" % status[1])
         return (value, data)
@@ -397,15 +423,19 @@ class miniesptool:
             written = 0
             address = offset
             stamp = time.monotonic()
+            last_print = time.monotonic()
             while filesize - file.tell() > 0:
-                print(
-                    "\rWriting at 0x%08x... (%d %%)"
-                    % (
-                        address + seq * self.FLASH_WRITE_SIZE,
-                        100 * (seq + 1) // blocks,
-                    ),
-                    end="",
-                )
+                # Only print progress every 10 seconds
+                if time.monotonic() - last_print >= 10:
+                    print(
+                        "\rWriting at 0x%08x... (%d %%)"
+                        % (
+                            address + seq * self.FLASH_WRITE_SIZE,
+                            100 * (seq + 1) // blocks,
+                        ),
+                        end="",
+                    )
+                    last_print = time.monotonic()
                 block = file.read(self.FLASH_WRITE_SIZE)
                 # Pad the last block
                 block = block + b"\xff" * (self.FLASH_WRITE_SIZE - len(block))

--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -45,9 +45,9 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_miniesptool.git"
 SYNC_PACKET = b"\x07\x07\x12 UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU"
 ESP32_DATAREGVALUE = 0x15122500
 ESP8266_DATAREGVALUE = 0x00062000
-ESP32_C6_DATAREGVALUE = 0x2ce0806f
+ESP32_C6_DATAREGVALUE = 0x2CE0806F
 ESP8266_ESP32_REG_DATA = 0x60000078
-ESP32_C6_REG_DATA = 0x40001000 # from https://github.com/espressif/esptool-js/blob/main/src/esploader.ts
+ESP32_C6_REG_DATA = 0x40001000  # from https://github.com/espressif/esptool-js/blob/main/src/esploader.ts
 
 
 # Commands supported by ESP8266 ROM bootloader
@@ -207,7 +207,7 @@ class miniesptool:
             else:
                 # Check for ESP32-C6
                 datareg = self.read_register(ESP32_C6_REG_DATA)
-                if (datareg == ESP32_C6_DATAREGVALUE):
+                if datareg == ESP32_C6_DATAREGVALUE:
                     self._chipfamily = ESP32C6
         return self._chipfamily
 
@@ -267,7 +267,9 @@ class miniesptool:
         if self._chipfamily == ESP32 or self._chipfamily == ESP32C6:
             self.check_command(ESP_SPI_ATTACH, bytes([0] * 8))
             # We are hardcoded for 4MB flash on ESP32
-            buffer = struct.pack("<IIIIII", 0, self._flashsize, 0x10000, 4096, 256, 0xFFFF)
+            buffer = struct.pack(
+                "<IIIIII", 0, self._flashsize, 0x10000, 4096, 256, 0xFFFF
+            )
             self.check_command(ESP_SPI_SET_PARAMS, buffer)
 
         num_blocks = (size + self._flash_write_size - 1) // self._flash_write_size
@@ -279,16 +281,23 @@ class miniesptool:
         stamp = time.monotonic()
         if self._chipfamily == ESP32C6:
             # ESP32-C6 requires a 5th parameter (the encryption flag)
-            buffer = struct.pack("<IIIII", erase_size, num_blocks, self._flash_write_size, offset, 0)
+            buffer = struct.pack(
+                "<IIIII", erase_size, num_blocks, self._flash_write_size, offset, 0
+            )
         else:
-            buffer = struct.pack("<IIII", erase_size, num_blocks, self._flash_write_size, offset)
+            buffer = struct.pack(
+                "<IIII", erase_size, num_blocks, self._flash_write_size, offset
+            )
         print(
             "Erase size %d, num_blocks %d, size %d, offset 0x%04x"
             % (erase_size, num_blocks, self._flash_write_size, offset)
         )
         self.check_command(ESP_FLASH_BEGIN, buffer, timeout=timeout)
         if size != 0:
-            print("Took %.2fs to erase %d flash blocks" % (time.monotonic() - stamp, num_blocks))
+            print(
+                "Took %.2fs to erase %d flash blocks"
+                % (time.monotonic() - stamp, num_blocks)
+            )
         return num_blocks
 
     def check_command(self, opcode, buffer, checksum=0, timeout=0.1):
@@ -307,9 +316,9 @@ class miniesptool:
             raise RuntimeError("Didn't get enough status bytes")
         status = data[-status_len:]
         data = data[:-status_len]
-        #print("status", status)
-        #print("value", value)
-        #print("data", data)
+        # print("status", status)
+        # print("value", value)
+        # print("data", data)
         if status[0] != 0:
             raise RuntimeError("Command failure error code 0x%02x" % status[1])
         return (value, data)
@@ -457,9 +466,7 @@ class miniesptool:
         any hardware resetting"""
         self.send_command(0x08, SYNC_PACKET)
         for _ in range(8):
-            reply, data = self.get_response(  # noqa: F841
-                0x08, 0.1
-            )
+            reply, data = self.get_response(0x08, 0.1)  # noqa: F841
             if not data:
                 continue
             if len(data) > 1 and data[0] == 0 and data[1] == 0:

--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -90,7 +90,8 @@ class miniesptool:
     when you have an ESP module wired to a board and need to upload new AT
     firmware. Its slow! Expect a few minutes when programming 1 MB flash."""
 
-    FLASH_WRITE_SIZE = 0x400
+    FLASH_WRITE_SIZE = 0x200
+    FLASH_WRITE_SIZE_C6 = 0x400
     FLASH_SECTOR_SIZE = 0x1000  # Flash sector size, minimum unit of erase.
     ESP_ROM_BAUD = 115200
 
@@ -114,6 +115,7 @@ class miniesptool:
         self._chipfamily = None
         self._chipname = None
         self._flashsize = flashsize
+        self._flash_write_size = self.FLASH_WRITE_SIZE
         # self._debug_led = DigitalInOut(board.D13)
         # self._debug_led.direction = Direction.OUTPUT
 
@@ -223,6 +225,7 @@ class miniesptool:
                 return "ESP8285"
             return "ESP8266EX"
         if self.chip_type == ESP32C6:
+            self._flash_write_size = self.FLASH_WRITE_SIZE_C6
             return "ESP32-C6"
         return None
 
@@ -267,7 +270,7 @@ class miniesptool:
             buffer = struct.pack("<IIIIII", 0, self._flashsize, 0x10000, 4096, 256, 0xFFFF)
             self.check_command(ESP_SPI_SET_PARAMS, buffer)
 
-        num_blocks = (size + self.FLASH_WRITE_SIZE - 1) // self.FLASH_WRITE_SIZE
+        num_blocks = (size + self._flash_write_size - 1) // self._flash_write_size
         if self._chipfamily == ESP8266:
             erase_size = self.get_erase_size(offset, size)
         else:
@@ -276,14 +279,13 @@ class miniesptool:
         stamp = time.monotonic()
         if self._chipfamily == ESP32C6:
             # ESP32-C6 requires a 5th parameter (the encryption flag)
-            buffer = struct.pack("<IIIII", erase_size, num_blocks, self.FLASH_WRITE_SIZE, offset, 0)
+            buffer = struct.pack("<IIIII", erase_size, num_blocks, self._flash_write_size, offset, 0)
         else:
-            buffer = struct.pack("<IIII", erase_size, num_blocks, self.FLASH_WRITE_SIZE, offset)
+            buffer = struct.pack("<IIII", erase_size, num_blocks, self._flash_write_size, offset)
         print(
             "Erase size %d, num_blocks %d, size %d, offset 0x%04x"
-            % (erase_size, num_blocks, self.FLASH_WRITE_SIZE, offset)
+            % (erase_size, num_blocks, self._flash_write_size, offset)
         )
-        print("Buffer: ", [hex(i) for i in buffer])
         self.check_command(ESP_FLASH_BEGIN, buffer, timeout=timeout)
         if size != 0:
             print("Took %.2fs to erase %d flash blocks" % (time.monotonic() - stamp, num_blocks))
@@ -430,15 +432,15 @@ class miniesptool:
                     print(
                         "\rWriting at 0x%08x... (%d %%)"
                         % (
-                            address + seq * self.FLASH_WRITE_SIZE,
+                            address + seq * self._flash_write_size,
                             100 * (seq + 1) // blocks,
                         ),
                         end="",
                     )
                     last_print = time.monotonic()
-                block = file.read(self.FLASH_WRITE_SIZE)
+                block = file.read(self._flash_write_size)
                 # Pad the last block
-                block = block + b"\xff" * (self.FLASH_WRITE_SIZE - len(block))
+                block = block + b"\xff" * (self._flash_write_size - len(block))
                 # print(block)
                 self.flash_block(block, seq, timeout=2)
                 seq += 1

--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -266,7 +266,7 @@ class miniesptool:
     def flash_begin(self, *, size=0, offset=0):
         """Prepare for flashing by attaching SPI chip and erasing the
         number of blocks requred."""
-        if self._chipfamily in (ESP32, ESP32C6):
+        if self._chipfamily in {ESP32, ESP32C6}:
             self.check_command(ESP_SPI_ATTACH, bytes([0] * 8))
             # We are hardcoded for 4MB flash on ESP32
             buffer = struct.pack("<IIIIII", 0, self._flashsize, 0x10000, 4096, 256, 0xFFFF)

--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -39,7 +39,7 @@ import time
 
 from digitalio import Direction
 
-__version__ = "0.2.25"
+__version__ = "0.0.0+auto.0"```
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_miniesptool.git"
 
 SYNC_PACKET = b"\x07\x07\x12 UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU"

--- a/adafruit_miniesptool.py
+++ b/adafruit_miniesptool.py
@@ -39,7 +39,7 @@ import time
 
 from digitalio import Direction
 
-__version__ = "0.0.0+auto.0"```
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_miniesptool.git"
 
 SYNC_PACKET = b"\x07\x07\x12 UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU"

--- a/examples/miniesptool_esp32c6.py
+++ b/examples/miniesptool_esp32c6.py
@@ -15,13 +15,15 @@ resetpin = board.ESP_RESET
 gpio0pin = board.I2S_IRQ
 
 uart = busio.UART(tx, rx, baudrate=115200, timeout=1)
-esptool = adafruit_miniesptool.miniesptool(uart, DigitalInOut(gpio0pin), DigitalInOut(resetpin), flashsize=4 * 1024 * 1024)
+esptool = adafruit_miniesptool.miniesptool(
+    uart, DigitalInOut(gpio0pin), DigitalInOut(resetpin), flashsize=4 * 1024 * 1024
+)
 esptool.sync()
 
 print("Synced")
 print("Found:", esptool.chip_name)
 if esptool.chip_name != "ESP32-C6":
-  raise RuntimeError("This example is for ESP32-C6 only")
+    raise RuntimeError("This example is for ESP32-C6 only")
 
 esptool.baudrate = 912600
 print("MAC ADDR: ", [hex(i) for i in esptool.mac_addr])

--- a/examples/miniesptool_esp32c6.py
+++ b/examples/miniesptool_esp32c6.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 Brent Rubell for Adafruit Industries
+# SPDX-License-Identifier: MIT
+import time
+import board
+import busio
+from digitalio import DigitalInOut, Direction
+import adafruit_miniesptool
+
+print("ESP32-C6 Nina-FW Loader")
+
+# Adafruit FruitJam (ESP32-C6) Configuration
+tx = board.ESP_TX
+rx = board.ESP_RX
+resetpin = board.ESP_RESET
+gpio0pin = board.I2S_IRQ
+
+uart = busio.UART(tx, rx, baudrate=115200, timeout=1)
+esptool = adafruit_miniesptool.miniesptool(uart, DigitalInOut(gpio0pin), DigitalInOut(resetpin), flashsize=4 * 1024 * 1024)
+esptool.sync()
+
+print("Synced")
+print("Found:", esptool.chip_name)
+if esptool.chip_name != "ESP32-C6":
+  raise RuntimeError("This example is for ESP32-C6 only")
+
+esptool.baudrate = 912600
+print("MAC ADDR: ", [hex(i) for i in esptool.mac_addr])
+
+# NOTE: Make sure to use the LATEST ninafw binary release and
+# rename it to ninafw.bin (or change the filename below)!
+esptool.flash_file("ninafw.bin", 0x0)
+
+print("Done flashing, resetting..")
+esptool.reset()
+time.sleep(0.5)

--- a/examples/miniesptool_esp32c6.py
+++ b/examples/miniesptool_esp32c6.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: 2025 Brent Rubell for Adafruit Industries
 # SPDX-License-Identifier: MIT
 import time
+
 import board
 import busio
 from digitalio import DigitalInOut, Direction
+
 import adafruit_miniesptool
 
 print("ESP32-C6 Nina-FW Loader")


### PR DESCRIPTION
This pull request adds support for the ESP32-C6 chip to this library. 

Why? We've started using the ESP32-C6 chip as an "AirLift" Co-Processor!

The workflow for updating the ESP32-C6 onboard the FruitJam is non-beginner friendly and requires the following steps:
1. Put board in DFU mode
2. Upload "Serial Passthru UF2" to board
3. Connect and configure board with WebESPTool or desktop `esptool.py`
4. Upload nina firmware binary
5. Reset Board
6. Re-Upload CircuitPython/WipperSnapper UF2

What we're proposing (cc @dhalbert): Provide a UF2 with CircuitPython, the latest nina-fw, and the flashing code for download. This would eliminate the need for another tool (Esptool/Webesptool) to just update nina-fw.

1. Put board in DFU Mode
2. Upload the UF2
3. Re-upload CircuitPython/WipperSnapper UF2

This pull request updates miniesptool to add compatibility for detecting and flashing a binary to an ESP32-C6:
* Added detection logic, constants, for ESP32-C6
* Tested flashing the latest nina-fw binary to the ESP32-C6 co-processor.

---

Tests:

Board: Adafruit CircuitPython 10.0.3 on 2025-10-17; Adafruit Fruit Jam with rp2350b
Binary: [NINA_ADAFRUIT-fruitjam_c6-3.2.0.bin](https://github.com/adafruit/nina-fw/releases/download/3.2.0/NINA_ADAFRUIT-fruitjam_c6-3.2.0.bin) 

Test Result (115200 baud config, 912600 baud flash)
```

ESP32-C6 Nina-FW Loader
Resetting
Synced
Detected ESP32-C6
Flash size: 0x200
NEw Flash size: 0x400
Found: ESP32-C6
MAC ADDR:  ['0x7c', '0x2c', '0x67', '0x5a', '0x7b', '0xc0']
Flashing...

Writing nina.bin w/filesize: 1626112
Erase size 1626112, num_blocks 1588, size 1024, offset 0x0000
Took 6.50s to erase 1588 flash blocks
Writing at 0x0018a800... (99 %)
Took 212.72s to write 1626112 bytes
Done flashing, resetting..
Code done running.
```